### PR TITLE
Fixing a few bugs in angle_to_sexigesimal and adding relevant tests

### DIFF
--- a/participants/Scicluna/pr_tutorial/buggy_function.py
+++ b/participants/Scicluna/pr_tutorial/buggy_function.py
@@ -20,13 +20,24 @@ def angle_to_sexigesimal(angle_in_degrees, decimals=3):
     if math.floor(decimals) != decimals:
         raise OSError('decimals should be an integer!')
 
-    hours_num = angle_in_degrees*24/180
+    #convert angle to half-open interval range [0,360)
+    angle_in_degrees %= 360
+
+    hours_num = angle_in_degrees*24/360
     hours = math.floor(hours_num)
 
     min_num = (hours_num - hours)*60
     minutes = math.floor(min_num)
 
-    seconds = (min_num - minutes)*60
+    seconds = round((min_num - minutes)*60, decimals)
 
-    format_string = '{}:{}:{:.' + str(decimals) + 'f}'
+    if round(seconds, decimals) >= 60:
+        minutes+=1
+        seconds-=60
+
+    if minutes > 59:
+        hours+=1
+        minutes-=60
+
+    format_string = '{0:02d}:{1:02d}:{2:0'+str(3+decimals)+ '.' + str(decimals) + 'f}'
     return format_string.format(hours, minutes, seconds)

--- a/participants/Scicluna/pr_tutorial/tests/test_buggy_function.py
+++ b/participants/Scicluna/pr_tutorial/tests/test_buggy_function.py
@@ -1,0 +1,23 @@
+from pr_tutorial.buggy_function import angle_to_sexigesimal
+
+
+
+def test_angle_to_sexigesimal_len():
+    """ A simple test that the length of the angle string is correct (HH:mm:ss.sss)  """
+
+    assert len(angle_to_sexigesimal(30)) == 12
+    #The length must be 12 if the string is formatted correctly with 3 decimal places and leading zeros
+
+
+def test_seconds_60():
+
+    assert angle_to_sexigesimal(350)[-6] == '0'
+    #For 350 degrees, the tens digit of the seconds should be 0, not 6
+
+def test_angle_wrapping():
+
+    assert angle_to_sexigesimal(370)[0:2] == '00'
+
+def test_angle_wrapping_negative():
+
+    assert angle_to_sexigesimal(-10)[0:2] == '24'


### PR DESCRIPTION
I found 3 small bugs in buggy_function.py. These related to:

1. Correct formatting of output as HH:MM:ss.sss i.e. 00:00:00.000 instead of 0:0:0.000
2. Angles outside the range [0,360) would not get wrapped to [0,24) but instead would appear outside that range
3. Hour angle was computed incorrectly (divided by 180 instead of 360)

I created tests to cover these specific failure modes.